### PR TITLE
Add canView() to SiteBanner.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ of the page they're viewing.
  * Set start/end dates for alert
  * Permission controls
  * Localisation of CMS UI controls and labels
+ * CMS users can make banners "dismissible", allowing users to hide banners after reading.
  * Optional: Rich-text editing (insert links and images)
  * Optional: Preview and publish through [versioneddataobjects](https://github.com/heyday/silverstripe-versioneddataobjects)
  * Optional: Sorting through [sortablegridfield](https://github.com/UndefinedOffset/SortableGridField)
@@ -44,8 +45,11 @@ The site banner can be configured in `admin/settings` now.
 In order to show the banners, you need to add them to your template:
 
 	<% loop $SiteConfig.SiteBanners %>
-        <div class="site-banner site-banner-$Type" role="alert">
+        <div id="site-banner-$ID" class="site-banner site-banner-$Type" role="alert">
             $Content
+            <% if $Dismiss %>
+                <button class="site-banner-close" aria-label="Close" data-banner="$ID">×</button>
+            <% end_if %>
         </div>
 	<% end_loop %>
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ The site banner can be configured in `admin/settings` now.
 In order to show the banners, you need to add them to your template:
 
 	<% loop $SiteConfig.SiteBanners %>
-        <div id="site-banner-$ID" class="site-banner site-banner-$Type" role="alert">
+        <div id="site-banner-$ID" class="site-banner site-banner-$Type" role="alert" data-id="$ID" aria-hidden="true">
             $Content
             <% if $Dismiss %>
-                <button class="site-banner-close" aria-label="Close" data-banner="$ID">×</button>
+                <button class="site-banner-close" aria-label="Close" data-id="$ID">×</button>
             <% end_if %>
         </div>
 	<% end_loop %>

--- a/_config.php
+++ b/_config.php
@@ -1,0 +1,5 @@
+<?php
+
+if(!defined('SITE_BANNER_DIR')) {
+    define('SITE_BANNER_DIR', basename(__DIR__));
+}

--- a/code/SiteBanner.php
+++ b/code/SiteBanner.php
@@ -182,6 +182,19 @@ class SiteBanner extends DataObject
      * @param null|Member $member
      * @return bool|int
      */
+    public function canView($member = null)
+    {
+        $extended = $this->extendedCan(__FUNCTION__, $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+        return Permission::checkMember($member, $this->config()->required_permission_codes);
+    }
+
+    /**
+     * @param null|Member $member
+     * @return bool|int
+     */
     public function canCreate($member = null)
     {
         $extended = $this->extendedCan(__FUNCTION__, $member);

--- a/code/SiteBanner.php
+++ b/code/SiteBanner.php
@@ -8,6 +8,7 @@ class SiteBanner extends DataObject
         'StartDate'   => 'SS_Datetime',
         'EndDate'     => 'SS_Datetime',
         'Sort'        => 'Int', // only used when 'sortablegridfield' is installed
+        'Dismiss'     => 'Boolean', // allows users to dismiss banners for the remainder of their session
     ];
 
     /**
@@ -54,7 +55,8 @@ class SiteBanner extends DataObject
                 'Content' => _t('SiteBanner.ContentFieldLabel', 'Banner content'),
                 'Type' => _t('SiteBanner.TypeFieldLabel', 'Banner type'),
                 'StartDate' => _t('SiteBanner.StartDateFieldLabel', 'Start date / time'),
-                'EndDate' => _t('SiteBanner.EndDateFieldLabel', 'End date / time')
+                'EndDate' => _t('SiteBanner.EndDateFieldLabel', 'End date / time'),
+                'Dismiss' => _t('SiteBanner.DismissLabel', 'Allow users to dismiss this banner')
             ]
         );
     }

--- a/code/SiteBanner.php
+++ b/code/SiteBanner.php
@@ -1,4 +1,5 @@
 <?php
+
 class SiteBanner extends DataObject
 {
 
@@ -52,11 +53,26 @@ class SiteBanner extends DataObject
         return array_merge(
             parent::fieldLabels($includerelations),
             [
-                'Content' => _t('SiteBanner.ContentFieldLabel', 'Banner content'),
-                'Type' => _t('SiteBanner.TypeFieldLabel', 'Banner type'),
-                'StartDate' => _t('SiteBanner.StartDateFieldLabel', 'Start date / time'),
-                'EndDate' => _t('SiteBanner.EndDateFieldLabel', 'End date / time'),
-                'Dismiss' => _t('SiteBanner.DismissLabel', 'Allow users to dismiss this banner')
+                'Content' => _t(
+                    'SiteBanner.ContentFieldLabel',
+                    'Banner content'
+                ),
+                'Type' => _t(
+                    'SiteBanner.TypeFieldLabel',
+                    'Banner type'
+                ),
+                'StartDate' => _t(
+                    'SiteBanner.StartDateFieldLabel',
+                    'Start date / time'
+                ),
+                'EndDate' => _t(
+                    'SiteBanner.EndDateFieldLabel',
+                    'End date / time'
+                ),
+                'Dismiss' => _t(
+                    'SiteBanner.DismissLabel',
+                    'Allow users to temporarily dismiss this banner in their browser session'
+                )
             ]
         );
     }

--- a/code/SiteBannerSiteConfigExtension.php
+++ b/code/SiteBannerSiteConfigExtension.php
@@ -41,8 +41,20 @@ class SiteBannerSiteConfigExtension extends DataExtension
      */
     public function getSiteBanners()
     {
+        Requirements::javascript(SITE_BANNER_DIR . '/javascript/site-banner.js');
+
         return SiteBanner::get()->filterByCallback(function ($banner) {
-            return $banner->isActive();
+            // don't display inactive banners
+            if (!$banner->isActive()) {
+                return false;
+            }
+
+            // don't display banners which have been dismissed by the user
+            if ($banner->Dismiss && Cookie::get('SiteBanner_' . $banner->ID . '_Dismiss')) {
+                return false;
+            }
+
+            return true;
         });
     }
 }

--- a/code/SiteBannerSiteConfigExtension.php
+++ b/code/SiteBannerSiteConfigExtension.php
@@ -41,20 +41,11 @@ class SiteBannerSiteConfigExtension extends DataExtension
      */
     public function getSiteBanners()
     {
+        Requirements::css(SITE_BANNER_DIR . '/css/site-banner.css');
         Requirements::javascript(SITE_BANNER_DIR . '/javascript/site-banner.js');
 
         return SiteBanner::get()->filterByCallback(function ($banner) {
-            // don't display inactive banners
-            if (!$banner->isActive()) {
-                return false;
-            }
-
-            // don't display banners which have been dismissed by the user
-            if ($banner->Dismiss && Cookie::get('SiteBanner_' . $banner->ID . '_Dismiss')) {
-                return false;
-            }
-
-            return true;
+            return $banner->isActive();
         });
     }
 }

--- a/css/site-banner.css
+++ b/css/site-banner.css
@@ -1,0 +1,3 @@
+.site-banner[aria-hidden='true'] {
+    display: none;
+}

--- a/javascript/site-banner.js
+++ b/javascript/site-banner.js
@@ -1,8 +1,12 @@
 (function () {
+    function getStorageKey(id) {
+        return 'SiteBanner_' + id + '_Dismiss';
+    }
+
     // Called when a user closes a banner.
     function callback(event) {
         var button = event.currentTarget;
-        var bannerId = button.dataset.banner;
+        var bannerId = button.dataset.id;
         var banner = document.getElementById('site-banner-' + bannerId);
 
         // The banner can only be closed once, so we don't need the click handler anymore.
@@ -12,14 +16,29 @@
         banner.parentNode.removeChild(banner);
 
         // Make sure the banner doesn't re-appear when the page is re-loaded.
-        document.cookie = 'SiteBanner_' + bannerId + '_Dismiss=1;path=/';
+        sessionStorage.setItem(getStorageKey(bannerId), true);
     }
 
-    var buttonNodeList = document.querySelectorAll('button.site-banner-close');
+    var bannersNodeList = document.querySelectorAll('.site-banner');
     var index = 0;
+    var bannerId = 0;
+    var button = null;
 
-    // Add click events to all banners which have close buttons.
-    for (index; index < buttonNodeList.length; index += 1) {
-        buttonNodeList[index].addEventListener('click', callback);
+    for (index; index < bannersNodeList.length; index += 1) {
+        bannerId = bannersNodeList[index].dataset.id;
+
+        // Don't display banners which have been dismissed.
+        if (sessionStorage.getItem(getStorageKey(bannerId))) {
+            continue;
+        }
+
+        // Display the banner.
+        bannersNodeList[index].setAttribute('aria-hidden', false);
+
+        // Add a click event the "dismiss" button, if it exists.
+        button = document.querySelector('#' + bannersNodeList[index].id + ' .site-banner-close');
+        if (button) {
+            button.addEventListener('click', callback);
+        }
     }
 }());

--- a/javascript/site-banner.js
+++ b/javascript/site-banner.js
@@ -12,7 +12,7 @@
         banner.parentNode.removeChild(banner);
 
         // Make sure the banner doesn't re-appear when the page is re-loaded.
-        document.cookie = 'SiteBanner_' + bannerId + '_Dismiss=1';
+        document.cookie = 'SiteBanner_' + bannerId + '_Dismiss=1;path=/';
     }
 
     var buttonNodeList = document.querySelectorAll('button.site-banner-close');

--- a/javascript/site-banner.js
+++ b/javascript/site-banner.js
@@ -6,7 +6,7 @@
     // Called when a user closes a banner.
     function callback(event) {
         var button = event.currentTarget;
-        var bannerId = button.dataset.id;
+        var bannerId = button.getAttribute('data-id');
         var banner = document.getElementById('site-banner-' + bannerId);
 
         // The banner can only be closed once, so we don't need the click handler anymore.
@@ -25,7 +25,7 @@
     var button = null;
 
     for (index; index < bannersNodeList.length; index += 1) {
-        bannerId = bannersNodeList[index].dataset.id;
+        bannerId = bannersNodeList[index].getAttribute('data-id');
 
         // Don't display banners which have been dismissed.
         if (sessionStorage.getItem(getStorageKey(bannerId))) {
@@ -38,7 +38,12 @@
         // Add a click event the "dismiss" button, if it exists.
         button = document.querySelector('#' + bannersNodeList[index].id + ' .site-banner-close');
         if (button) {
-            button.addEventListener('click', callback);
+            // hide close button for browsers without sessionStorage compatibility
+            if (!sessionStorage) {
+                button.style.display = 'none';
+            } else {
+                button.addEventListener('click', callback);
+            }
         }
     }
 }());

--- a/javascript/site-banner.js
+++ b/javascript/site-banner.js
@@ -1,0 +1,25 @@
+(function () {
+    // Called when a user closes a banner.
+    function callback(event) {
+        var button = event.currentTarget;
+        var bannerId = button.dataset.banner;
+        var banner = document.getElementById('site-banner-' + bannerId);
+
+        // The banner can only be closed once, so we don't need the click handler anymore.
+        button.removeEventListener('click', callback);
+
+        // Remove the banner from the page.
+        banner.parentNode.removeChild(banner);
+
+        // Make sure the banner doesn't re-appear when the page is re-loaded.
+        document.cookie = 'SiteBanner_' + bannerId + '_Dismiss=1';
+    }
+
+    var buttonNodeList = document.querySelectorAll('button.site-banner-close');
+    var index = 0;
+
+    // Add click events to all banners which have close buttons.
+    for (index; index < buttonNodeList.length; index += 1) {
+        buttonNodeList[index].addEventListener('click', callback);
+    }
+}());


### PR DESCRIPTION
Adding a canView() to SiteBanner.php

Reason for this is that non-admin's with the EDIT_SITECONFIG permission won't be able to view the SiteBanners in  the CMS because it falls back to DataObject->canView() which checks for ADMIN

Note: this branch was forked from the branch in this PR https://github.com/NZTA/silverstripe-sitebanner/pull/3 - which should be merged first
