### PR TITLE
Implement model admin with option to enable/disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,29 @@ of the page they're viewing.
 
 ## Configuration
 
-Add the following to your YAML config to activate the module:
+#### Site settings
+Add the following to your YAML config to configure the module:
 
 	SilverStripe\SiteConfig\SiteConfig:
 	  extensions:
 	    - NZTA\SiteBanner\Extensions\SiteConfigExtension
 
+Add the following environment variable to you `.env` file to activate the
+the module in site settings:
+
+```
+SITEBANNER_SITECONFIG=1
+```
+
 The site banner can be configured in `admin/settings` now.
+
+#### Model admin
+Add the following environment variable to your `.env` file to enable
+the model admin interface for managing the site banners
+
+```
+SITEBANNER_MODELADMIN=1
+```
 
 ## Templates
 

--- a/src/Extensions/SiteConfigExtension.php
+++ b/src/Extensions/SiteConfigExtension.php
@@ -3,16 +3,14 @@
 namespace NZTA\SiteBanner\Extensions;
 
 use NZTA\SiteBanner\Models\SiteBanner;
+use SilverStripe\Core\Environment;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
-use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataExtension;
-use SilverStripe\View\Requirements;
-use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
 /**
  * Allows editing of site banner data "globally".
@@ -24,6 +22,10 @@ class SiteConfigExtension extends DataExtension
 
     public function updateCMSFields(FieldList $fields): void
     {
+        if (!Environment::getEnv('SITEBANNER_SITECONFIG')) {
+            return;
+        }
+
         $fields->findOrMakeTab(
             'Root.SiteBanner',
             _t(self::class . '.TabTitle', 'Site Banners'),
@@ -38,21 +40,10 @@ class SiteConfigExtension extends DataExtension
         $gridConfig->removeComponentsByType(GridFieldDeleteAction::class);
 
         if (class_exists('Symbiote\GridFieldExtensions\GridFieldOrderableRows')) {
-            $grid->getConfig()->addComponent(GridFieldOrderableRows::create('Sort'));
+            $grid->getConfig()->addComponent(\Symbiote\GridFieldExtensions\GridFieldOrderableRows::create('Sort'));
         }
 
         $fields->addFieldToTab('Root.SiteBanner', $grid);
-    }
-
-    /**
-     * Get all displayable site banners
-     */
-    public function getSiteBanners(): ArrayList
-    {
-        Requirements::css('nzta/silverstripe-sitebanner: client/css/site-banner.css');
-        Requirements::javascript('nzta/silverstripe-sitebanner: client/javascript/site-banner.js');
-
-        return SiteBanner::get()->filterByCallback(static fn ($banner) => $banner->isActive());
     }
 
 }

--- a/src/Models/Admin.php
+++ b/src/Models/Admin.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace NZTA\SiteBanner\Models;
+
+use SilverStripe\Admin\ModelAdmin;
+use SilverStripe\Core\Environment;
+use SilverStripe\Forms\GridField\GridFieldConfig;
+use SilverStripe\Security\Member;
+
+class Admin extends ModelAdmin
+{
+    private static array $managed_models = [
+        'banners' => [
+            'title' => 'Site banners',
+            'dataClass' => SiteBanner::class,
+        ],
+    ];
+
+    private static string $url_segment = 'site-banners';
+
+    private static float $menu_priority = 1;
+
+    private static string $menu_title = 'Site banners';
+
+    private static string $menu_icon_class = 'font-icon-attention';
+
+    /**
+     * @param Member|null $member
+     * @return bool
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     */
+    public function canView($member = null)
+    {
+        return Environment::getEnv('SITEBANNER_MODELADMIN') && parent::canView($member);
+    }
+
+    public function getGridFieldConfig(): GridFieldConfig
+    {
+        $config = parent::getGridFieldConfig();
+
+        if (class_exists('Symbiote\GridFieldExtensions\GridFieldOrderableRows')) {
+            $config->addComponent(new \Symbiote\GridFieldExtensions\GridFieldOrderableRows('Sort'));
+        }
+
+        return $config;
+    }
+
+}

--- a/src/Models/SiteBanner.php
+++ b/src/Models/SiteBanner.php
@@ -80,6 +80,7 @@ class SiteBanner extends DataObject
     private static string $default_sort = 'Sort';
 
     private static array $summary_fields = [
+        'Type.UpperCase' => 'Type',
         'Content.Summary' => 'Content',
     ];
 

--- a/src/Templates/TemplateProvider.php
+++ b/src/Templates/TemplateProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace NZTA\SiteBanner\Templates;
+
+use NZTA\SiteBanner\Models\SiteBanner;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\View\Requirements;
+use SilverStripe\View\TemplateGlobalProvider;
+
+class TemplateProvider implements TemplateGlobalProvider
+{
+    public static function get_template_global_variables(): array
+    {
+        return [
+            'SiteBanners' => 'getSiteBanners',
+        ];
+    }
+
+    /**
+     * Get all displayable site banners
+     */
+    public static function getSiteBanners(): ArrayList
+    {
+        Requirements::css('nzta/silverstripe-sitebanner: client/css/site-banner.css');
+        Requirements::javascript('nzta/silverstripe-sitebanner: client/javascript/site-banner.js');
+
+        return SiteBanner::get()->filterByCallback(static function ($banner) {
+            return $banner->isActive();
+        });
+    }
+}

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NZTA\SiteBanner\Tests;
+
+use NZTA\SiteBanner\Models\Admin;
+use SilverStripe\Core\Environment;
+use SilverStripe\Dev\SapphireTest;
+
+/**
+ * @phpcs:disable SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
+ */
+class AdminTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    public function testIsModelAdminActive(): void
+    {
+        $this->logInWithPermission('ADMIN');
+
+        $admin = new Admin();
+        // Assert can't access model admin without environment var
+        $this->assertFalse($admin->canView());
+
+        Environment::setEnv('SITEBANNER_MODELADMIN', 1);
+        // Assert can access model admin with environment var
+        $this->assertTrue($admin->canView());
+    }
+
+}

--- a/tests/SiteBannerTest.php
+++ b/tests/SiteBannerTest.php
@@ -53,5 +53,4 @@ class SiteBannerTest extends SapphireTest
         DBDatetime::set_mock_now('2017-01-01 13:00:00');
         $this->assertFalse($banner->isActive());
     }
-
 }

--- a/tests/SiteConfigExtensionTest.php
+++ b/tests/SiteConfigExtensionTest.php
@@ -3,8 +3,9 @@
 namespace NZTA\SiteBanner\Tests;
 
 use NZTA\SiteBanner\Extensions\SiteConfigExtension;
-use NZTA\SiteBanner\Models\SiteBanner;
+use SilverStripe\Core\Environment;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\SiteConfig\SiteConfig;
 
 /**
@@ -13,28 +14,18 @@ use SilverStripe\SiteConfig\SiteConfig;
  */
 class SiteConfigExtensionTest extends SapphireTest
 {
-
-    protected $usesDatabase = true;
-
-    protected static $required_extensions = [
-        SiteConfig::class => [
-            SiteConfigExtension::class,
-        ],
-    ];
-
-    public function testFiltersInactiveBanners(): void
+    public function testIsSiteConfigGridFieldActive(): void
     {
-        $activeBanner = new SiteBanner();
-        $activeBanner->Content = 'test';
-        $activeBanner->write();
+        $extension = new SiteConfigExtension();
 
-        $inactiveBanner = new SiteBanner();
-        $inactiveBanner->Content = '';
-        $inactiveBanner->write();
+        $fields = (new SiteConfig())->getCMSFields();
+        $extension->updateCMSFields($fields);
 
-        $banners = singleton(SiteConfig::class)->getSiteBanners();
-        $this->assertContains($activeBanner->ID, $banners->column('ID'));
-        $this->assertNotContains($inactiveBanner->ID, $banners->column('ID'));
+        $this->assertNull($fields->dataFieldByName('SiteBanners'));
+
+        Environment::setEnv('SITEBANNER_SITECONFIG', 1);
+        $extension->updateCMSFields($fields);
+
+        $this->assertInstanceOf(GridField::class, $fields->dataFieldByName('SiteBanners'));
     }
-
 }

--- a/tests/TemplateProviderTest.php
+++ b/tests/TemplateProviderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace NZTA\SiteBanner\Tests;
+
+use NZTA\SiteBanner\Models\SiteBanner;
+use NZTA\SiteBanner\Templates\TemplateProvider;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
+
+/**
+ * @phpcs:disable SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
+ * @phpcs:disable SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint
+ * @phpcs:disable SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
+ * @phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint
+ */
+class TemplateProviderTest extends SapphireTest
+{
+    public function testFiltersInactiveBanners(): void
+    {
+        // Mock data list with 3 site banners 2 active, 1 inactive
+        $mockDataList = new class(SiteBanner::class) extends DataList {
+            public function filterByCallback($callback)
+            {
+                return ArrayList::create([
+                    SiteBanner::create([
+                        'Content' => 'test',
+                    ]),
+                    SiteBanner::create([
+                        'Content' => 'test2',
+                    ]),
+                    SiteBanner::create([
+                        'Content' => '',
+                    ]),
+                ])->filterByCallback($callback);
+            }
+        };
+        Injector::inst()->registerService($mockDataList, DataList::class);
+
+        $banners = TemplateProvider::getSiteBanners();
+
+        // Assert that active site banner returned
+        self::assertContains('test', $banners->column('Content'));
+        $this->assertCount(2, $banners);
+    }
+}


### PR DESCRIPTION

- Make use of site config extension of model admin to manage the site banner optional using environment variables. 
- Add Alert type to banners grid field.
