### PR TITLE
Add support for Silverstripe 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Allows CMS authors to create site-wide banners, to alert visitors of important i
 
 ![CMS Preview](docs/_img/cms-screenshot.png)
 
+## Requirements
+
+* php >= 8.0
+* SilverStripe ^4 || ^5
+
 ## Installation
 
 	composer require nzta/silverstripe-sitebanner

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Allows CMS authors to create site-wide banners, to alert visitors of important i
 ## Requirements
 
 * php >= 8.0
-* SilverStripe ^4 || ^5
+* SilverStripe ^5
+
+For a Silverstripe CMS ^4 compatible version of this module, please see the [releases <=3.0.1](https://github.com/silverstripe/silverstripe-sitebanner/tree/3.0.1).
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">= 8.0",
-        "silverstripe/cms": "^4 || ^5"
+        "silverstripe/cms": "^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">= 8.0",
-        "silverstripe/cms": "^4"
+        "silverstripe/cms": "^4 || ^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/tests/SiteBannerTest.php
+++ b/tests/SiteBannerTest.php
@@ -12,7 +12,7 @@ class SiteBannerTest extends SapphireTest
 
     public function testIsActiveWithoutEmbargoWithEmptyContent(): void
     {
-        Config::inst()->merge(SiteBanner::class, 'embargo_enabled', false);
+        Config::inst()->merge(SiteBanner::class, null , ['embargo_enabled' => false]);
         $banner = new SiteBanner();
         $banner->Content = null;
         $this->assertFalse($banner->isActive());
@@ -20,7 +20,7 @@ class SiteBannerTest extends SapphireTest
 
     public function testIsActiveWithoutEmbargoWithContent(): void
     {
-        Config::inst()->merge('SiteBanner', 'embargo_enabled', false);
+        Config::inst()->merge('SiteBanner', null , ['embargo_enabled' => false]);
         $banner = new SiteBanner();
         $banner->Content = 'test';
         $this->assertTrue($banner->isActive());
@@ -28,7 +28,7 @@ class SiteBannerTest extends SapphireTest
 
     public function testIsActiveWithEmbargoStartDate(): void
     {
-        Config::inst()->merge('SiteBanner', 'embargo_enabled', true);
+        Config::inst()->merge('SiteBanner', null , ['embargo_enabled' => true]);
         $banner = new SiteBanner();
         $banner->Content = 'test';
         $banner->StartDate = '2017-01-01 12:00:00';
@@ -42,7 +42,7 @@ class SiteBannerTest extends SapphireTest
 
     public function testIsActiveWithEmbargoEndDate(): void
     {
-        Config::inst()->merge('SiteBanner', 'embargo_enabled', true);
+        Config::inst()->merge('SiteBanner', null , ['embargo_enabled' => true]);
         $banner = new SiteBanner();
         $banner->Content = 'test';
         $banner->EndDate = '2017-01-01 12:00:00';

--- a/tests/SiteBannerTest.php
+++ b/tests/SiteBannerTest.php
@@ -12,7 +12,7 @@ class SiteBannerTest extends SapphireTest
 
     public function testIsActiveWithoutEmbargoWithEmptyContent(): void
     {
-        Config::inst()->merge(SiteBanner::class, null , ['embargo_enabled' => false]);
+        Config::inst()->merge(SiteBanner::class, null, ['embargo_enabled' => false]);
         $banner = new SiteBanner();
         $banner->Content = null;
         $this->assertFalse($banner->isActive());
@@ -20,7 +20,7 @@ class SiteBannerTest extends SapphireTest
 
     public function testIsActiveWithoutEmbargoWithContent(): void
     {
-        Config::inst()->merge('SiteBanner', null , ['embargo_enabled' => false]);
+        Config::inst()->merge('SiteBanner', null, ['embargo_enabled' => false]);
         $banner = new SiteBanner();
         $banner->Content = 'test';
         $this->assertTrue($banner->isActive());
@@ -28,7 +28,7 @@ class SiteBannerTest extends SapphireTest
 
     public function testIsActiveWithEmbargoStartDate(): void
     {
-        Config::inst()->merge('SiteBanner', null , ['embargo_enabled' => true]);
+        Config::inst()->merge('SiteBanner', null, ['embargo_enabled' => true]);
         $banner = new SiteBanner();
         $banner->Content = 'test';
         $banner->StartDate = '2017-01-01 12:00:00';
@@ -42,7 +42,7 @@ class SiteBannerTest extends SapphireTest
 
     public function testIsActiveWithEmbargoEndDate(): void
     {
-        Config::inst()->merge('SiteBanner', null , ['embargo_enabled' => true]);
+        Config::inst()->merge('SiteBanner', null, ['embargo_enabled' => true]);
         $banner = new SiteBanner();
         $banner->Content = 'test';
         $banner->EndDate = '2017-01-01 12:00:00';


### PR DESCRIPTION
Upgrading this module for supporting Silverstripe 5 is an easy one, just need to add `^5` as the required version for `silverstripe/cms`

Tested it with vanilla CMS and another project that is using this module, it works well on both.